### PR TITLE
Add documentation for installation errors: This commit adds a new doc…

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,7 +1,6 @@
 site_name: KubeStellar
 repo_url: https://github.com/kubestellar/kubestellar
-# site_url: https://docs.kubestellar.io/
-site_url: https://letsgetstartedwithbub.github.io/kubestellar/
+site_url: https://docs.kubestellar.io/
 
 repo_short_name: kubestellar/kubestellar
 repo_default_file_path: kubestellar


### PR DESCRIPTION
…umentation page to address the sysctl fs.inotify.max_user_watches error during Kubernetes installation. It includes steps to resolve the issue for Rancher and other Docker runtimes. #2847

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #
